### PR TITLE
fix: Admin panel job lifecycle, dispute resolution, and verification improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ apps/mobile-worker/build/
 *.freezed.dart
 
 TODO.md
+DIAGRAMS.md

--- a/apps/admin/src/pages/CategoriesPage.tsx
+++ b/apps/admin/src/pages/CategoriesPage.tsx
@@ -91,19 +91,27 @@ export default function CategoriesPage() {
     setShowForm(true);
   };
 
+  const [alert, setAlert] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+  const showAlert = (type: 'success' | 'error', message: string) => {
+    setAlert({ type, message });
+    setTimeout(() => setAlert(null), 3000);
+  };
+
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setFormLoading(true);
     try {
       if (editingId) {
         await updateCategory(editingId, formData);
+        showAlert('success', 'Category updated');
       } else {
         await createCategory(formData);
+        showAlert('success', 'Category created');
       }
       setShowForm(false);
       fetchCategories();
-    } catch (err) {
-      console.error(err);
+    } catch (err: any) {
+      showAlert('error', err.message || 'Failed to save category');
     } finally {
       setFormLoading(false);
     }
@@ -113,9 +121,10 @@ export default function CategoriesPage() {
     if (!confirm('Are you sure you want to delete this category?')) return;
     try {
       await deleteCategory(id);
+      showAlert('success', 'Category deleted');
       fetchCategories();
-    } catch (err) {
-      console.error(err);
+    } catch (err: any) {
+      showAlert('error', err.message || 'Failed to delete category');
     }
   };
 

--- a/apps/admin/src/pages/DisputesPage.tsx
+++ b/apps/admin/src/pages/DisputesPage.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react';
-import { getDisputes } from '../services/api';
+import { getDisputes, resolveDispute } from '../services/api';
 import {
   AlertTriangle,
   MessageSquare,
   User,
   Clock,
   CheckCircle,
+  ShieldCheck,
+  DollarSign,
 } from 'lucide-react';
 
 export default function DisputesPage() {
@@ -13,11 +15,16 @@ export default function DisputesPage() {
   const [loading, setLoading] = useState(true);
   const [selectedDispute, setSelectedDispute] = useState<any | null>(null);
 
-  useEffect(() => {
+  const fetchDisputes = () => {
+    setLoading(true);
     getDisputes()
       .then((res) => setDisputes(res.disputes || res.data || []))
       .catch(console.error)
       .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchDisputes();
   }, []);
 
   if (loading) {
@@ -34,7 +41,7 @@ export default function DisputesPage() {
         <CheckCircle size={48} className="mx-auto text-green-400 mb-4" />
         <h3 className="text-lg font-semibold text-warm-800">No disputes</h3>
         <p className="text-sm text-warm-500 mt-1">
-          No cancelled or disputed jobs to review.
+          No cancelled jobs with assigned workers to review.
         </p>
       </div>
     );
@@ -85,7 +92,7 @@ export default function DisputesPage() {
               </div>
               <div className="flex items-center gap-2 text-sm text-warm-600">
                 <User size={14} className="text-warm-400" />
-                <span>Worker: {job.worker?.user?.name || 'Not assigned'}</span>
+                <span>Worker: {job.worker?.user?.name || 'N/A'}</span>
               </div>
               {job._count?.messages > 0 && (
                 <div className="flex items-center gap-1 text-sm text-warm-500">
@@ -100,123 +107,270 @@ export default function DisputesPage() {
 
       {/* Dispute Detail Modal */}
       {selectedDispute && (
-        <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
-          <div className="bg-white rounded-xl max-w-2xl w-full max-h-[80vh] overflow-y-auto">
-            <div className="p-6 border-b border-warm-300 flex items-center justify-between">
-              <h3 className="font-semibold text-warm-800 flex items-center gap-2">
-                <AlertTriangle size={18} className="text-orange-500" />
-                Dispute Details
-              </h3>
-              <button
-                onClick={() => setSelectedDispute(null)}
-                className="text-warm-400 hover:text-warm-700"
-              >
-                &times;
-              </button>
+        <DisputeDetailModal
+          dispute={selectedDispute}
+          onClose={() => setSelectedDispute(null)}
+          onResolved={() => {
+            setSelectedDispute(null);
+            fetchDisputes();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function DisputeDetailModal({
+  dispute,
+  onClose,
+  onResolved,
+}: {
+  dispute: any;
+  onClose: () => void;
+  onResolved: () => void;
+}) {
+  const [resolution, setResolution] = useState<'refund_customer' | 'pay_worker' | 'no_compensation'>('no_compensation');
+  const [notes, setNotes] = useState('');
+  const [resolving, setResolving] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  const handleResolve = async () => {
+    const labels: Record<string, string> = {
+      refund_customer: 'refund the customer',
+      pay_worker: 'compensate the worker',
+      no_compensation: 'resolve with no compensation',
+    };
+    if (!confirm(`Are you sure you want to ${labels[resolution]}?`)) return;
+
+    setResolving(true);
+    setError('');
+    try {
+      await resolveDispute(dispute.id, { resolution, notes: notes || undefined });
+      setSuccess('Dispute resolved successfully');
+      setTimeout(onResolved, 1000);
+    } catch (err: any) {
+      setError(err.message || 'Failed to resolve dispute');
+    } finally {
+      setResolving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
+      <div className="bg-white rounded-xl max-w-2xl w-full max-h-[80vh] overflow-y-auto">
+        <div className="p-6 border-b border-warm-300 flex items-center justify-between">
+          <h3 className="font-semibold text-warm-800 flex items-center gap-2">
+            <AlertTriangle size={18} className="text-orange-500" />
+            Dispute Details
+          </h3>
+          <button
+            onClick={onClose}
+            className="text-warm-400 hover:text-warm-700"
+          >
+            &times;
+          </button>
+        </div>
+        <div className="p-6 space-y-4">
+          <div>
+            <h4 className="text-lg font-semibold text-warm-800">
+              {dispute.title}
+            </h4>
+            {dispute.description && (
+              <p className="text-sm text-warm-600 mt-1">
+                {dispute.description}
+              </p>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <p className="text-xs text-warm-500">Customer</p>
+              <p className="text-sm font-medium text-warm-800">
+                {dispute.customer?.user?.name || 'N/A'}
+              </p>
+              <p className="text-xs text-warm-400">
+                {dispute.customer?.user?.email}
+              </p>
             </div>
-            <div className="p-6 space-y-4">
-              <div>
-                <h4 className="text-lg font-semibold text-warm-800">
-                  {selectedDispute.title}
-                </h4>
-                {selectedDispute.description && (
-                  <p className="text-sm text-warm-600 mt-1">
-                    {selectedDispute.description}
-                  </p>
-                )}
-              </div>
-
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <p className="text-xs text-warm-500">Customer</p>
-                  <p className="text-sm font-medium text-warm-800">
-                    {selectedDispute.customer?.user?.name || 'N/A'}
-                  </p>
-                  <p className="text-xs text-warm-400">
-                    {selectedDispute.customer?.user?.email}
-                  </p>
-                </div>
-                <div>
-                  <p className="text-xs text-warm-500">Worker</p>
-                  <p className="text-sm font-medium text-warm-800">
-                    {selectedDispute.worker?.user?.name || 'Not assigned'}
-                  </p>
-                  <p className="text-xs text-warm-400">
-                    {selectedDispute.worker?.user?.email}
-                  </p>
-                </div>
-                <div>
-                  <p className="text-xs text-warm-500">Price</p>
-                  <p className="text-sm font-medium text-warm-800">
-                    {selectedDispute.price
-                      ? `Rs. ${selectedDispute.price.toLocaleString()}`
-                      : 'N/A'}
-                  </p>
-                </div>
-                <div>
-                  <p className="text-xs text-warm-500">Category</p>
-                  <p className="text-sm font-medium text-warm-800">
-                    {selectedDispute.category?.name || 'N/A'}
-                  </p>
-                </div>
-              </div>
-
-              {selectedDispute.review && (
-                <div className="border-t border-warm-300 pt-4">
-                  <h5 className="font-medium text-warm-800 mb-2">Review</h5>
-                  <div className="flex items-center gap-1 mb-1">
-                    {[1, 2, 3, 4, 5].map((i) => (
-                      <span
-                        key={i}
-                        className={`text-lg ${
-                          i <= selectedDispute.review.rating
-                            ? 'text-yellow-400'
-                            : 'text-gray-300'
-                        }`}
-                      >
-                        &#9733;
-                      </span>
-                    ))}
-                  </div>
-                  {selectedDispute.review.comment && (
-                    <p className="text-sm text-warm-600">
-                      {selectedDispute.review.comment}
-                    </p>
-                  )}
-                </div>
-              )}
-
-              {selectedDispute.messages && selectedDispute.messages.length > 0 && (
-                <div className="border-t border-warm-300 pt-4">
-                  <h5 className="font-medium text-warm-800 mb-2 flex items-center gap-2">
-                    <MessageSquare size={16} />
-                    Recent Messages
-                  </h5>
-                  <div className="space-y-2 max-h-60 overflow-y-auto">
-                    {selectedDispute.messages.map((msg: any) => (
-                      <div
-                        key={msg.id}
-                        className="p-3 bg-warm-50 rounded-lg"
-                      >
-                        <div className="flex items-center justify-between mb-1">
-                          <p className="text-xs font-medium text-warm-700">
-                            {msg.sender?.name || 'Unknown'}
-                          </p>
-                          <p className="text-xs text-warm-400 flex items-center gap-1">
-                            <Clock size={10} />
-                            {new Date(msg.createdAt).toLocaleString()}
-                          </p>
-                        </div>
-                        <p className="text-sm text-warm-600">{msg.content}</p>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
+            <div>
+              <p className="text-xs text-warm-500">Worker</p>
+              <p className="text-sm font-medium text-warm-800">
+                {dispute.worker?.user?.name || 'N/A'}
+              </p>
+              <p className="text-xs text-warm-400">
+                {dispute.worker?.user?.email}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-warm-500">Price</p>
+              <p className="text-sm font-medium text-warm-800">
+                {dispute.price
+                  ? `Rs. ${dispute.price.toLocaleString()}`
+                  : 'N/A'}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-warm-500">Category</p>
+              <p className="text-sm font-medium text-warm-800">
+                {dispute.category?.name || 'N/A'}
+              </p>
             </div>
           </div>
+
+          {dispute.payment && (
+            <div className="border-t border-warm-300 pt-4">
+              <h5 className="font-medium text-warm-800 mb-2 flex items-center gap-2">
+                <DollarSign size={16} /> Payment
+              </h5>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <p className="text-xs text-warm-500">Amount</p>
+                  <p className="text-sm font-medium text-warm-800">
+                    Rs. {dispute.payment.amount?.toLocaleString()}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs text-warm-500">Status</p>
+                  <p className="text-sm font-medium text-warm-800">
+                    {dispute.payment.status}
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {dispute.review && (
+            <div className="border-t border-warm-300 pt-4">
+              <h5 className="font-medium text-warm-800 mb-2">Review</h5>
+              <div className="flex items-center gap-1 mb-1">
+                {[1, 2, 3, 4, 5].map((i) => (
+                  <span
+                    key={i}
+                    className={`text-lg ${
+                      i <= dispute.review.rating
+                        ? 'text-yellow-400'
+                        : 'text-gray-300'
+                    }`}
+                  >
+                    &#9733;
+                  </span>
+                ))}
+              </div>
+              {dispute.review.comment && (
+                <p className="text-sm text-warm-600">
+                  {dispute.review.comment}
+                </p>
+              )}
+            </div>
+          )}
+
+          {dispute.messages && dispute.messages.length > 0 && (
+            <div className="border-t border-warm-300 pt-4">
+              <h5 className="font-medium text-warm-800 mb-2 flex items-center gap-2">
+                <MessageSquare size={16} />
+                Recent Messages
+              </h5>
+              <div className="space-y-2 max-h-60 overflow-y-auto">
+                {dispute.messages.map((msg: any) => (
+                  <div
+                    key={msg.id}
+                    className="p-3 bg-warm-50 rounded-lg"
+                  >
+                    <div className="flex items-center justify-between mb-1">
+                      <p className="text-xs font-medium text-warm-700">
+                        {msg.sender?.name || 'Unknown'}
+                      </p>
+                      <p className="text-xs text-warm-400 flex items-center gap-1">
+                        <Clock size={10} />
+                        {new Date(msg.createdAt).toLocaleString()}
+                      </p>
+                    </div>
+                    <p className="text-sm text-warm-600">{msg.content}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Resolution Section */}
+          <div className="border-t border-warm-300 pt-4">
+            <h5 className="font-medium text-warm-800 mb-3 flex items-center gap-2">
+              <ShieldCheck size={16} />
+              Resolve Dispute
+            </h5>
+
+            <div className="space-y-2 mb-3">
+              <label className="flex items-center gap-3 p-3 border border-warm-200 rounded-lg cursor-pointer hover:bg-warm-50 transition-colors">
+                <input
+                  type="radio"
+                  name="resolution"
+                  value="refund_customer"
+                  checked={resolution === 'refund_customer'}
+                  onChange={() => setResolution('refund_customer')}
+                  className="accent-primary-600"
+                />
+                <div>
+                  <p className="text-sm font-medium text-warm-800">Refund Customer</p>
+                  <p className="text-xs text-warm-500">Issue a full refund to the customer for this job</p>
+                </div>
+              </label>
+              <label className="flex items-center gap-3 p-3 border border-warm-200 rounded-lg cursor-pointer hover:bg-warm-50 transition-colors">
+                <input
+                  type="radio"
+                  name="resolution"
+                  value="pay_worker"
+                  checked={resolution === 'pay_worker'}
+                  onChange={() => setResolution('pay_worker')}
+                  className="accent-primary-600"
+                />
+                <div>
+                  <p className="text-sm font-medium text-warm-800">Compensate Worker</p>
+                  <p className="text-xs text-warm-500">Pay the worker for work completed before cancellation</p>
+                </div>
+              </label>
+              <label className="flex items-center gap-3 p-3 border border-warm-200 rounded-lg cursor-pointer hover:bg-warm-50 transition-colors">
+                <input
+                  type="radio"
+                  name="resolution"
+                  value="no_compensation"
+                  checked={resolution === 'no_compensation'}
+                  onChange={() => setResolution('no_compensation')}
+                  className="accent-primary-600"
+                />
+                <div>
+                  <p className="text-sm font-medium text-warm-800">No Compensation</p>
+                  <p className="text-xs text-warm-500">Close the dispute without issuing any compensation</p>
+                </div>
+              </label>
+            </div>
+
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Add resolution notes (optional)..."
+              rows={2}
+              className="w-full px-3 py-2 border border-warm-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-400 resize-none mb-3"
+            />
+
+            {error && (
+              <div className="p-3 bg-red-50 text-red-700 rounded-lg text-sm mb-3">{error}</div>
+            )}
+            {success && (
+              <div className="p-3 bg-green-50 text-green-700 rounded-lg text-sm mb-3">{success}</div>
+            )}
+
+            <button
+              onClick={handleResolve}
+              disabled={resolving}
+              className="flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50 text-sm font-medium transition-colors"
+            >
+              <ShieldCheck size={16} />
+              {resolving ? 'Resolving...' : 'Resolve Dispute'}
+            </button>
+          </div>
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/apps/admin/src/pages/JobsPage.tsx
+++ b/apps/admin/src/pages/JobsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
-import { getJobs, getCategories } from '../services/api';
+import { getJobs, getCategories, adminCloseJob } from '../services/api';
 import {
   Search,
   ChevronLeft,
@@ -9,6 +9,7 @@ import {
   Clock,
   DollarSign,
   Filter,
+  CheckCircle,
 } from 'lucide-react';
 
 const STATUS_OPTIONS = [
@@ -247,13 +248,49 @@ export default function JobsPage() {
 
       {/* Job Detail Modal */}
       {selectedJob && (
-        <JobDetailModal job={selectedJob} onClose={() => setSelectedJob(null)} />
+        <JobDetailModal
+          job={selectedJob}
+          onClose={() => setSelectedJob(null)}
+          onJobUpdated={() => {
+            setSelectedJob(null);
+            fetchJobs();
+          }}
+        />
       )}
     </div>
   );
 }
 
-function JobDetailModal({ job, onClose }: { job: any; onClose: () => void }) {
+function JobDetailModal({
+  job,
+  onClose,
+  onJobUpdated,
+}: {
+  job: any;
+  onClose: () => void;
+  onJobUpdated: () => void;
+}) {
+  const [closing, setClosing] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  const handleCloseJob = async () => {
+    if (!confirm('Are you sure you want to close this job?')) return;
+    setClosing(true);
+    setError('');
+    try {
+      await adminCloseJob(job.id);
+      setSuccess('Job closed successfully');
+      setTimeout(onJobUpdated, 1000);
+    } catch (err: any) {
+      setError(err.message || 'Failed to close job');
+    } finally {
+      setClosing(false);
+    }
+  };
+
+  const canClose = job.status === 'REVIEWING' || job.status === 'COMPLETED';
+
   return (
     <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
       <div className="bg-white rounded-xl max-w-2xl w-full max-h-[80vh] overflow-y-auto">
@@ -370,6 +407,29 @@ function JobDetailModal({ job, onClose }: { job: any; onClose: () => void }) {
                   messages
                 </p>
               </div>
+            </div>
+          )}
+
+          {error && (
+            <div className="p-3 bg-red-50 text-red-700 rounded-lg text-sm">{error}</div>
+          )}
+          {success && (
+            <div className="p-3 bg-green-50 text-green-700 rounded-lg text-sm">{success}</div>
+          )}
+
+          {canClose && (
+            <div className="border-t border-warm-300 pt-4">
+              <button
+                onClick={handleCloseJob}
+                disabled={closing}
+                className="flex items-center gap-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50 text-sm font-medium transition-colors"
+              >
+                <CheckCircle size={16} />
+                {closing ? 'Closing...' : 'Close Job'}
+              </button>
+              <p className="text-xs text-warm-400 mt-1">
+                This will mark the job as completed and notify both parties.
+              </p>
             </div>
           )}
         </div>

--- a/apps/admin/src/pages/UsersPage.tsx
+++ b/apps/admin/src/pages/UsersPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
-import { getUsers, updateUserStatus } from '../services/api';
+import { getUsers, updateUserStatus, deleteUser, verifyWorker } from '../services/api';
 import {
   Search,
   ChevronLeft,
@@ -7,6 +7,7 @@ import {
   UserCheck,
   UserX,
   Eye,
+  Trash2,
 } from 'lucide-react';
 
 export default function UsersPage() {
@@ -43,12 +44,31 @@ export default function UsersPage() {
     fetchUsers();
   }, [fetchUsers]);
 
+  const [alert, setAlert] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+
+  const showAlert = (type: 'success' | 'error', message: string) => {
+    setAlert({ type, message });
+    setTimeout(() => setAlert(null), 3000);
+  };
+
   const toggleStatus = async (userId: string, currentStatus: boolean) => {
     try {
       await updateUserStatus(userId, !currentStatus);
+      showAlert('success', `User ${currentStatus ? 'deactivated' : 'activated'} successfully`);
       fetchUsers();
-    } catch (err) {
-      console.error(err);
+    } catch (err: any) {
+      showAlert('error', err.message || 'Failed to update user status');
+    }
+  };
+
+  const handleDelete = async (userId: string, userName: string) => {
+    if (!window.confirm(`Are you sure you want to delete "${userName}"? This cannot be undone.`)) return;
+    try {
+      await deleteUser(userId);
+      showAlert('success', `User "${userName}" deleted successfully`);
+      fetchUsers();
+    } catch (err: any) {
+      showAlert('error', err.message || 'Failed to delete user');
     }
   };
 
@@ -56,6 +76,11 @@ export default function UsersPage() {
 
   return (
     <div className="space-y-4">
+      {alert && (
+        <div className={`p-3 rounded-lg text-sm font-medium ${alert.type === 'success' ? 'bg-green-50 text-green-700 border border-green-200' : 'bg-red-50 text-red-700 border border-red-200'}`}>
+          {alert.message}
+        </div>
+      )}
       {/* Filters */}
       <div className="bg-white rounded-xl border border-warm-300 p-4">
         <div className="flex flex-col sm:flex-row gap-3">
@@ -205,6 +230,13 @@ export default function UsersPage() {
                             <UserCheck size={16} />
                           )}
                         </button>
+                        <button
+                          onClick={() => handleDelete(user.id, user.name)}
+                          className="p-1.5 text-warm-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+                          title="Delete user"
+                        >
+                          <Trash2 size={16} />
+                        </button>
                       </div>
                     </td>
                   </tr>
@@ -328,6 +360,39 @@ function UserDetailModal({ user, onClose }: { user: any; onClose: () => void }) 
                 <InfoItem label="Total Jobs" value={user.workerProfile.totalJobs} />
                 <InfoItem label="Available" value={user.workerProfile.isAvailable ? 'Yes' : 'No'} />
                 <InfoItem label="Bio" value={user.workerProfile.bio || 'N/A'} />
+              </div>
+              <div className="flex gap-2 mt-3">
+                {user.workerProfile.verificationStatus !== 'VERIFIED' && (
+                  <button
+                    onClick={async () => {
+                      try {
+                        await verifyWorker(user.id, { status: 'VERIFIED' });
+                        onClose();
+                      } catch (err: any) {
+                        alert(err.message || 'Failed to verify');
+                      }
+                    }}
+                    className="px-3 py-1.5 bg-green-50 text-green-700 border border-green-200 rounded-lg text-xs font-medium hover:bg-green-100 transition-colors"
+                  >
+                    Verify Worker
+                  </button>
+                )}
+                {user.workerProfile.verificationStatus === 'VERIFIED' && (
+                  <button
+                    onClick={async () => {
+                      if (!window.confirm('Revoke this worker\'s verification?')) return;
+                      try {
+                        await verifyWorker(user.id, { status: 'PENDING' });
+                        onClose();
+                      } catch (err: any) {
+                        alert(err.message || 'Failed to revoke');
+                      }
+                    }}
+                    className="px-3 py-1.5 bg-red-50 text-red-700 border border-red-200 rounded-lg text-xs font-medium hover:bg-red-100 transition-colors"
+                  >
+                    Revoke Verification
+                  </button>
+                )}
               </div>
             </div>
           )}

--- a/apps/admin/src/pages/VerificationPage.tsx
+++ b/apps/admin/src/pages/VerificationPage.tsx
@@ -1,383 +1,468 @@
-import { useEffect, useState } from 'react';
-import { getPendingWorkers, verifyWorker } from '../services/api';
-import type { BadgeLevel } from '../types';
+import { useEffect, useState, useCallback } from 'react';
+import { getAllWorkers, verifyWorker } from '../services/api';
 import {
+  Search,
   ShieldCheck,
   ShieldX,
+  RotateCcw,
+  Eye,
+  X,
   User,
-  MapPin,
-  CreditCard,
   Star,
   Briefcase,
+  FileText,
   CheckCircle,
   XCircle,
-  AlertCircle,
-  FileText,
-  Award,
-  X,
-  Eye,
+  Clock,
 } from 'lucide-react';
-
-const BADGE_COLORS: Record<BadgeLevel, string> = {
-  TRAINEE: 'bg-gray-100 text-gray-700',
-  BRONZE: 'bg-amber-100 text-amber-800',
-  SILVER: 'bg-slate-200 text-slate-700',
-  GOLD: 'bg-yellow-100 text-yellow-800',
-  PLATINUM: 'bg-indigo-100 text-indigo-800',
-};
 
 export default function VerificationPage() {
   const [workers, setWorkers] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState('');
   const [actionLoading, setActionLoading] = useState<string | null>(null);
-  const [rejectTarget, setRejectTarget] = useState<string | null>(null);
-  const [rejectionReason, setRejectionReason] = useState('');
-  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [selectedWorker, setSelectedWorker] = useState<any | null>(null);
+  const [alert, setAlert] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
 
-  const fetchWorkers = () => {
+  const showAlert = (type: 'success' | 'error', message: string) => {
+    setAlert({ type, message });
+    setTimeout(() => setAlert(null), 3000);
+  };
+
+  const fetchWorkers = useCallback(() => {
     setLoading(true);
-    getPendingWorkers()
-      .then((res) => setWorkers(res.workers || res.data || []))
+    getAllWorkers(statusFilter || undefined)
+      .then((res) => setWorkers(res.workers || []))
       .catch(console.error)
       .finally(() => setLoading(false));
-  };
+  }, [statusFilter]);
 
   useEffect(() => {
     fetchWorkers();
-  }, []);
+  }, [fetchWorkers]);
 
-  const handleVerify = async (userId: string) => {
+  const handleAction = async (userId: string, data: any, label: string) => {
     setActionLoading(userId);
     try {
-      await verifyWorker(userId, 'VERIFIED');
+      await verifyWorker(userId, data);
+      showAlert('success', label);
       fetchWorkers();
-    } catch (err) {
-      console.error(err);
+      if (selectedWorker?.userId === userId) {
+        setSelectedWorker(null);
+      }
+    } catch (err: any) {
+      showAlert('error', err.message || 'Action failed');
     } finally {
       setActionLoading(null);
     }
   };
 
-  const handleReject = async () => {
-    if (!rejectTarget || !rejectionReason.trim()) return;
-    setActionLoading(rejectTarget);
-    try {
-      await verifyWorker(rejectTarget, 'REJECTED', rejectionReason.trim());
-      setRejectTarget(null);
-      setRejectionReason('');
-      fetchWorkers();
-    } catch (err) {
-      console.error(err);
-    } finally {
-      setActionLoading(null);
-    }
+  const filteredWorkers = workers.filter((w) => {
+    if (!search) return true;
+    const q = search.toLowerCase();
+    return (
+      (w.user?.name || '').toLowerCase().includes(q) ||
+      (w.user?.email || '').toLowerCase().includes(q) ||
+      (w.nicNumber || '').toLowerCase().includes(q)
+    );
+  });
+
+  const statusBadge = (status: string) => {
+    const styles: Record<string, string> = {
+      NOT_SUBMITTED: 'bg-gray-100 text-gray-600',
+      PENDING: 'bg-orange-100 text-orange-700',
+      VERIFIED: 'bg-green-100 text-green-700',
+      REJECTED: 'bg-red-100 text-red-700',
+    };
+    return (
+      <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${styles[status] || 'bg-warm-100 text-warm-700'}`}>
+        {status === 'VERIFIED' ? <CheckCircle size={10} /> : status === 'REJECTED' ? <XCircle size={10} /> : <Clock size={10} />}
+        {status}
+      </span>
+    );
   };
 
-  if (loading) {
+  const badgeBadge = (level: string) => {
+    const styles: Record<string, string> = {
+      TRAINEE: 'bg-gray-100 text-gray-700',
+      BRONZE: 'bg-amber-100 text-amber-800',
+      SILVER: 'bg-slate-200 text-slate-700',
+      GOLD: 'bg-yellow-100 text-yellow-800',
+      PLATINUM: 'bg-indigo-100 text-indigo-800',
+    };
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="w-8 h-8 border-3 border-primary-200 border-t-primary-500 rounded-full animate-spin" />
-      </div>
+      <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${styles[level] || styles.TRAINEE}`}>
+        {level}
+      </span>
     );
-  }
-
-  if (workers.length === 0) {
-    return (
-      <div className="bg-white rounded-xl border border-warm-300 p-12 text-center">
-        <CheckCircle size={48} className="mx-auto text-green-400 mb-4" />
-        <h3 className="text-lg font-semibold text-warm-800">All caught up!</h3>
-        <p className="text-sm text-warm-500 mt-1">
-          No workers pending verification.
-        </p>
-      </div>
-    );
-  }
+  };
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center gap-2 text-sm text-warm-500">
-        <AlertCircle size={16} />
-        <span>{workers.length} worker(s) awaiting verification</span>
+      {alert && (
+        <div className={`p-3 rounded-lg text-sm font-medium ${alert.type === 'success' ? 'bg-green-50 text-green-700 border border-green-200' : 'bg-red-50 text-red-700 border border-red-200'}`}>
+          {alert.message}
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="bg-white rounded-xl border border-warm-300 p-4">
+        <div className="flex flex-col sm:flex-row gap-3">
+          <div className="relative flex-1">
+            <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-warm-400" />
+            <input
+              type="text"
+              placeholder="Search by name, email, or NIC..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-full pl-9 pr-3 py-2 border border-warm-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-400"
+            />
+          </div>
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className="px-3 py-2 border border-warm-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-400"
+          >
+            <option value="">All Status</option>
+            <option value="NOT_SUBMITTED">Not Submitted</option>
+            <option value="PENDING">Pending</option>
+            <option value="VERIFIED">Verified</option>
+            <option value="REJECTED">Rejected</option>
+          </select>
+        </div>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        {workers.map((worker) => (
-          <div
-            key={worker.id}
-            className="bg-white rounded-xl border border-warm-300 p-5"
-          >
-            <div className="flex items-start gap-4">
-              <div className="w-12 h-12 bg-orange-100 rounded-full flex items-center justify-center flex-shrink-0">
-                {worker.user?.avatarUrl ? (
-                  <img
-                    src={worker.user.avatarUrl}
-                    alt=""
-                    className="w-12 h-12 rounded-full object-cover"
-                  />
-                ) : (
-                  <User size={20} className="text-orange-600" />
+      {/* Table */}
+      <div className="bg-white rounded-xl border border-warm-300 overflow-hidden">
+        {loading ? (
+          <div className="flex items-center justify-center h-48">
+            <div className="w-8 h-8 border-3 border-primary-200 border-t-primary-500 rounded-full animate-spin" />
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead>
+                <tr className="bg-warm-50 border-b border-warm-300">
+                  <th className="text-left px-4 py-3 text-xs font-medium text-warm-500 uppercase">Worker</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-warm-500 uppercase">NIC</th>
+                  <th className="text-center px-4 py-3 text-xs font-medium text-warm-500 uppercase">NIC</th>
+                  <th className="text-center px-4 py-3 text-xs font-medium text-warm-500 uppercase">Quals</th>
+                  <th className="text-center px-4 py-3 text-xs font-medium text-warm-500 uppercase">BG Check</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-warm-500 uppercase">Badge</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-warm-500 uppercase">Status</th>
+                  <th className="text-right px-4 py-3 text-xs font-medium text-warm-500 uppercase">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {filteredWorkers.map((w) => (
+                  <tr key={w.id} className="hover:bg-warm-50">
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-3">
+                        <div className="w-9 h-9 bg-primary-100 rounded-full flex items-center justify-center flex-shrink-0">
+                          <span className="text-primary-800 text-sm font-medium">
+                            {w.user?.name?.[0]?.toUpperCase() || '?'}
+                          </span>
+                        </div>
+                        <div className="min-w-0">
+                          <p className="text-sm font-medium text-warm-800 truncate">{w.user?.name || 'Unknown'}</p>
+                          <p className="text-xs text-warm-500 truncate">{w.user?.email}</p>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-sm text-warm-600">{w.nicNumber || 'N/A'}</td>
+                    <td className="px-4 py-3 text-center">
+                      {w.nicVerified ? (
+                        <CheckCircle size={16} className="inline text-green-500" />
+                      ) : w.nicFrontUrl ? (
+                        <Clock size={16} className="inline text-orange-400" />
+                      ) : (
+                        <XCircle size={16} className="inline text-gray-300" />
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-center">
+                      {w.qualificationsVerified ? (
+                        <CheckCircle size={16} className="inline text-green-500" />
+                      ) : (w.qualificationDocs || []).length > 0 ? (
+                        <Clock size={16} className="inline text-orange-400" />
+                      ) : (
+                        <XCircle size={16} className="inline text-gray-300" />
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-center">
+                      {w.backgroundCheckVerified ? (
+                        <CheckCircle size={16} className="inline text-green-500" />
+                      ) : w.backgroundCheckUrl ? (
+                        <Clock size={16} className="inline text-orange-400" />
+                      ) : (
+                        <XCircle size={16} className="inline text-gray-300" />
+                      )}
+                    </td>
+                    <td className="px-4 py-3">{badgeBadge(w.badgeLevel || 'TRAINEE')}</td>
+                    <td className="px-4 py-3">{statusBadge(w.verificationStatus)}</td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center justify-end gap-1">
+                        <button
+                          onClick={() => setSelectedWorker(w)}
+                          className="p-1.5 text-warm-400 hover:text-primary-600 hover:bg-primary-50 rounded-lg transition-colors"
+                          title="View & manage"
+                        >
+                          <Eye size={16} />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+                {filteredWorkers.length === 0 && (
+                  <tr>
+                    <td colSpan={8} className="px-4 py-12 text-center text-sm text-warm-500">
+                      No workers found
+                    </td>
+                  </tr>
                 )}
-              </div>
-              <div className="flex-1 min-w-0">
-                <h4 className="font-semibold text-warm-800">
-                  {worker.user?.name || 'Unknown'}
-                </h4>
-                <p className="text-sm text-warm-500">{worker.user?.email}</p>
-                <p className="text-xs text-warm-400 mt-0.5">
-                  Applied {new Date(worker.user?.createdAt).toLocaleDateString()}
-                </p>
-              </div>
-              <div className="flex flex-col items-end gap-1">
-                <span className="px-2 py-0.5 bg-orange-100 text-orange-700 rounded-full text-xs font-medium">
-                  PENDING
-                </span>
-                {worker.badgeLevel && (
-                  <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${BADGE_COLORS[worker.badgeLevel as BadgeLevel] || BADGE_COLORS.TRAINEE}`}>
-                    <Award size={10} className="inline mr-1" />
-                    {worker.badgeLevel}
-                  </span>
-                )}
-              </div>
-            </div>
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
 
-            <div className="mt-4 grid grid-cols-2 gap-3">
-              <DetailItem
-                icon={CreditCard}
-                label="NIC Number"
-                value={worker.nicNumber || 'Not provided'}
-              />
-              <DetailItem
-                icon={MapPin}
-                label="Location"
-                value={
-                  worker.latitude
-                    ? `${worker.latitude.toFixed(4)}, ${worker.longitude.toFixed(4)}`
-                    : 'Not set'
-                }
-              />
-              <DetailItem
-                icon={Star}
-                label="Rating"
-                value={`${worker.rating} / 5`}
-              />
-              <DetailItem
-                icon={Briefcase}
-                label="Total Jobs"
-                value={worker.totalJobs}
-              />
-            </div>
+      {/* Detail Modal */}
+      {selectedWorker && (
+        <WorkerVerifyModal
+          worker={selectedWorker}
+          onClose={() => { setSelectedWorker(null); fetchWorkers(); }}
+          onAction={handleAction}
+          actionLoading={actionLoading}
+        />
+      )}
+    </div>
+  );
+}
 
-            {/* Document Viewer Section */}
-            <div className="mt-4">
-              <p className="text-xs text-warm-500 mb-2 font-medium">Documents</p>
-              <div className="grid grid-cols-3 gap-2">
-                <DocThumbnail
-                  label="NIC Front"
-                  url={worker.nicFrontUrl}
-                  onPreview={setPreviewUrl}
-                />
-                <DocThumbnail
-                  label="NIC Back"
-                  url={worker.nicBackUrl}
-                  onPreview={setPreviewUrl}
-                />
-                <DocThumbnail
-                  label="Background"
-                  url={worker.backgroundCheckUrl}
-                  onPreview={setPreviewUrl}
-                />
+function WorkerVerifyModal({ worker: w, onClose, onAction, actionLoading }: {
+  worker: any;
+  onClose: () => void;
+  onAction: (userId: string, data: any, label: string) => void;
+  actionLoading: string | null;
+}) {
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [rejectReason, setRejectReason] = useState('');
+  const [showRejectForm, setShowRejectForm] = useState(false);
+  const isLoading = actionLoading === w.userId;
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
+        <div className="bg-white rounded-xl max-w-2xl w-full max-h-[85vh] overflow-y-auto">
+          <div className="p-6 border-b border-warm-300 flex items-center justify-between sticky top-0 bg-white z-10">
+            <h3 className="text-lg font-semibold text-warm-800">Worker Verification</h3>
+            <button onClick={onClose} className="p-1 hover:bg-warm-100 rounded-lg"><X size={20} /></button>
+          </div>
+          <div className="p-6 space-y-6">
+            {/* Worker info */}
+            <div className="flex items-center gap-4">
+              <div className="w-14 h-14 bg-primary-100 rounded-full flex items-center justify-center">
+                <User size={24} className="text-primary-600" />
               </div>
-              {worker.qualificationDocs && worker.qualificationDocs.length > 0 && (
-                <div className="mt-2">
-                  <p className="text-xs text-warm-400 mb-1">Qualifications</p>
-                  <div className="flex flex-wrap gap-1">
-                    {worker.qualificationDocs.map((doc: any) => (
-                      <button
-                        key={doc.id}
-                        onClick={() => setPreviewUrl(doc.url)}
-                        className="flex items-center gap-1 px-2 py-1 bg-blue-50 text-blue-700 rounded text-xs hover:bg-blue-100 transition-colors"
-                      >
-                        <FileText size={12} />
-                        {doc.title}
-                      </button>
-                    ))}
-                  </div>
+              <div>
+                <h4 className="text-lg font-semibold text-warm-800">{w.user?.name || 'Unknown'}</h4>
+                <p className="text-sm text-warm-500">{w.user?.email}</p>
+                <div className="flex gap-2 mt-1">
+                  <span className="text-xs text-warm-400">NIC: {w.nicNumber || 'N/A'}</span>
+                  <span className="text-xs text-warm-400">Rating: <Star size={10} className="inline text-yellow-500" /> {w.rating?.toFixed(1) || '0.0'}</span>
+                  <span className="text-xs text-warm-400">Jobs: {w.totalJobs || 0}</span>
                 </div>
-              )}
+              </div>
             </div>
 
-            {worker.bio && (
-              <div className="mt-3 p-3 bg-warm-50 rounded-lg">
-                <p className="text-xs text-warm-500 mb-1">Bio</p>
-                <p className="text-sm text-warm-700">{worker.bio}</p>
-              </div>
-            )}
+            {/* 1. NIC Verification */}
+            <DocSection
+              title="National Identity Card"
+              verified={w.nicVerified}
+              hasDoc={!!(w.nicFrontUrl || w.nicBackUrl)}
+              docs={[
+                { label: 'NIC Front', url: w.nicFrontUrl },
+                { label: 'NIC Back', url: w.nicBackUrl },
+              ]}
+              onPreview={setPreviewUrl}
+              onVerify={() => onAction(w.userId, { nicVerified: true }, 'NIC verified')}
+              onRevoke={() => onAction(w.userId, { nicVerified: false }, 'NIC verification revoked')}
+              isLoading={isLoading}
+            />
 
-            {worker.categories && worker.categories.length > 0 && (
-              <div className="mt-3">
-                <p className="text-xs text-warm-500 mb-1">Skills</p>
-                <div className="flex flex-wrap gap-1">
-                  {worker.categories.map((wc: any) => (
-                    <span
-                      key={wc.category?.id || wc.categoryId}
-                      className="px-2 py-0.5 bg-primary-50 text-primary-800 rounded-full text-xs"
+            {/* 2. Qualifications */}
+            <DocSection
+              title="Qualifications & Certificates"
+              verified={w.qualificationsVerified}
+              hasDoc={(w.qualificationDocs || []).length > 0}
+              docs={(w.qualificationDocs || []).map((d: any) => ({ label: d.title, url: d.url }))}
+              onPreview={setPreviewUrl}
+              onVerify={() => onAction(w.userId, { qualificationsVerified: true }, 'Qualifications verified')}
+              onRevoke={() => onAction(w.userId, { qualificationsVerified: false }, 'Qualifications verification revoked')}
+              isLoading={isLoading}
+            />
+
+            {/* 3. Background Check */}
+            <DocSection
+              title="Background Check"
+              verified={w.backgroundCheckVerified}
+              hasDoc={!!w.backgroundCheckUrl}
+              docs={[{ label: 'Police Certificate', url: w.backgroundCheckUrl }]}
+              onPreview={setPreviewUrl}
+              onVerify={() => onAction(w.userId, { backgroundCheckVerified: true }, 'Background check verified')}
+              onRevoke={() => onAction(w.userId, { backgroundCheckVerified: false }, 'Background check revoked')}
+              isLoading={isLoading}
+            />
+
+            {/* Overall actions */}
+            <div className="border-t border-warm-200 pt-4">
+              <div className="flex gap-2">
+                {!showRejectForm ? (
+                  <>
+                    <button
+                      onClick={() => onAction(w.userId, { status: 'PENDING' }, 'Status reset to pending')}
+                      disabled={isLoading}
+                      className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 border border-warm-300 text-warm-700 rounded-lg text-sm font-medium hover:bg-warm-50 disabled:opacity-50 transition-colors"
                     >
-                      {wc.category?.name || 'Unknown'}
-                    </span>
-                  ))}
-                </div>
+                      <RotateCcw size={16} />
+                      Reset to Pending
+                    </button>
+                    <button
+                      onClick={() => setShowRejectForm(true)}
+                      disabled={isLoading}
+                      className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 bg-red-600 text-white rounded-lg text-sm font-medium hover:bg-red-700 disabled:opacity-50 transition-colors"
+                    >
+                      <ShieldX size={16} />
+                      Reject All
+                    </button>
+                  </>
+                ) : (
+                  <div className="w-full space-y-3">
+                    <textarea
+                      value={rejectReason}
+                      onChange={(e) => setRejectReason(e.target.value)}
+                      rows={3}
+                      placeholder="Reason for rejection (shown to worker)..."
+                      className="w-full px-3 py-2 border border-warm-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-red-400 resize-none"
+                    />
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => setShowRejectForm(false)}
+                        className="flex-1 px-4 py-2 border border-warm-300 text-warm-700 rounded-lg text-sm"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        onClick={() => {
+                          onAction(w.userId, { status: 'REJECTED', rejectionReason: rejectReason }, 'Worker rejected');
+                          setShowRejectForm(false);
+                        }}
+                        disabled={!rejectReason.trim() || isLoading}
+                        className="flex-1 px-4 py-2 bg-red-600 text-white rounded-lg text-sm font-medium disabled:opacity-50"
+                      >
+                        Confirm Reject
+                      </button>
+                    </div>
+                  </div>
+                )}
               </div>
-            )}
-
-            <div className="mt-4 flex items-center gap-2">
-              <button
-                onClick={() => handleVerify(worker.userId)}
-                disabled={actionLoading === worker.userId}
-                className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-green-600 text-white rounded-lg text-sm font-medium hover:bg-green-700 disabled:opacity-50 transition-colors"
-              >
-                <ShieldCheck size={16} />
-                Approve
-              </button>
-              <button
-                onClick={() => {
-                  setRejectTarget(worker.userId);
-                  setRejectionReason('');
-                }}
-                disabled={actionLoading === worker.userId}
-                className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-red-600 text-white rounded-lg text-sm font-medium hover:bg-red-700 disabled:opacity-50 transition-colors"
-              >
-                <ShieldX size={16} />
-                Reject
-              </button>
             </div>
           </div>
+        </div>
+      </div>
+
+      {/* Document Preview */}
+      {previewUrl && (
+        <div className="fixed inset-0 bg-black/70 z-[60] flex items-center justify-center p-4" onClick={() => setPreviewUrl(null)}>
+          <div className="relative max-w-3xl max-h-[90vh] bg-white rounded-xl overflow-hidden" onClick={(e) => e.stopPropagation()}>
+            <button onClick={() => setPreviewUrl(null)} className="absolute top-3 right-3 z-10 w-8 h-8 bg-white rounded-full flex items-center justify-center shadow-md">
+              <X size={16} />
+            </button>
+            <img src={previewUrl} alt="Document" className="max-w-full max-h-[85vh] object-contain" />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+function DocSection({ title, verified, hasDoc, docs, onPreview, onVerify, onRevoke, isLoading }: {
+  title: string;
+  verified: boolean;
+  hasDoc: boolean;
+  docs: { label: string; url: string | null }[];
+  onPreview: (url: string) => void;
+  onVerify: () => void;
+  onRevoke: () => void;
+  isLoading: boolean;
+}) {
+  return (
+    <div className="border border-warm-200 rounded-xl p-4">
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <FileText size={16} className="text-warm-500" />
+          <h5 className="font-medium text-warm-800">{title}</h5>
+        </div>
+        {verified ? (
+          <span className="flex items-center gap-1 px-2 py-0.5 bg-green-100 text-green-700 rounded-full text-xs font-medium">
+            <CheckCircle size={12} /> Verified
+          </span>
+        ) : hasDoc ? (
+          <span className="flex items-center gap-1 px-2 py-0.5 bg-orange-100 text-orange-700 rounded-full text-xs font-medium">
+            <Clock size={12} /> Pending Review
+          </span>
+        ) : (
+          <span className="flex items-center gap-1 px-2 py-0.5 bg-gray-100 text-gray-500 rounded-full text-xs font-medium">
+            <XCircle size={12} /> Not Submitted
+          </span>
+        )}
+      </div>
+
+      {/* Document thumbnails */}
+      <div className="flex flex-wrap gap-2 mb-3">
+        {docs.map((doc, i) => (
+          doc.url ? (
+            <button
+              key={i}
+              onClick={() => onPreview(doc.url!)}
+              className="flex items-center gap-2 px-3 py-2 bg-blue-50 text-blue-700 rounded-lg text-xs hover:bg-blue-100 transition-colors"
+            >
+              <Eye size={14} />
+              {doc.label}
+            </button>
+          ) : (
+            <span key={i} className="flex items-center gap-2 px-3 py-2 bg-warm-50 text-warm-400 rounded-lg text-xs">
+              <XCircle size={14} />
+              {doc.label} — not uploaded
+            </span>
+          )
         ))}
       </div>
 
-      {/* Rejection Reason Modal */}
-      {rejectTarget && (
-        <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
-          <div className="bg-white rounded-xl max-w-md w-full">
-            <div className="p-6 border-b border-warm-300 flex items-center justify-between">
-              <h3 className="font-semibold text-warm-800">Rejection Reason</h3>
-              <button
-                onClick={() => setRejectTarget(null)}
-                className="text-warm-400 hover:text-warm-700"
-              >
-                <X size={20} />
-              </button>
-            </div>
-            <div className="p-6 space-y-4">
-              <p className="text-sm text-warm-500">
-                Please provide a reason for rejecting this worker's verification.
-                This will be shown to the worker.
-              </p>
-              <textarea
-                value={rejectionReason}
-                onChange={(e) => setRejectionReason(e.target.value)}
-                rows={4}
-                placeholder="e.g. NIC image is blurry, please re-upload a clearer photo..."
-                className="w-full px-3 py-2 border border-warm-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-red-400 resize-none"
-              />
-              <div className="flex gap-3">
-                <button
-                  onClick={() => setRejectTarget(null)}
-                  className="flex-1 px-4 py-2 border border-warm-300 text-warm-700 rounded-lg text-sm font-medium hover:bg-warm-50 transition-colors"
-                >
-                  Cancel
-                </button>
-                <button
-                  onClick={handleReject}
-                  disabled={!rejectionReason.trim() || actionLoading === rejectTarget}
-                  className="flex-1 px-4 py-2 bg-red-600 text-white rounded-lg text-sm font-medium hover:bg-red-700 disabled:opacity-50 transition-colors"
-                >
-                  {actionLoading === rejectTarget ? 'Rejecting...' : 'Confirm Reject'}
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Document Preview Modal */}
-      {previewUrl && (
-        <div
-          className="fixed inset-0 bg-black/70 z-50 flex items-center justify-center p-4"
-          onClick={() => setPreviewUrl(null)}
-        >
-          <div
-            className="relative max-w-3xl max-h-[90vh] bg-white rounded-xl overflow-hidden"
-            onClick={(e) => e.stopPropagation()}
-          >
+      {/* Verify / Revoke buttons */}
+      {hasDoc && (
+        <div className="flex gap-2">
+          {!verified ? (
             <button
-              onClick={() => setPreviewUrl(null)}
-              className="absolute top-3 right-3 z-10 w-8 h-8 bg-white rounded-full flex items-center justify-center shadow-md hover:bg-warm-50"
+              onClick={onVerify}
+              disabled={isLoading}
+              className="flex items-center gap-1.5 px-3 py-1.5 bg-green-600 text-white rounded-lg text-xs font-medium hover:bg-green-700 disabled:opacity-50 transition-colors"
             >
-              <X size={16} />
+              <ShieldCheck size={14} />
+              Verify
             </button>
-            {previewUrl.endsWith('.pdf') ? (
-              <iframe src={previewUrl} className="w-full h-[80vh]" />
-            ) : (
-              <img
-                src={previewUrl}
-                alt="Document preview"
-                className="max-w-full max-h-[85vh] object-contain"
-              />
-            )}
-          </div>
+          ) : (
+            <button
+              onClick={onRevoke}
+              disabled={isLoading}
+              className="flex items-center gap-1.5 px-3 py-1.5 bg-orange-500 text-white rounded-lg text-xs font-medium hover:bg-orange-600 disabled:opacity-50 transition-colors"
+            >
+              <RotateCcw size={14} />
+              Revoke
+            </button>
+          )}
         </div>
       )}
     </div>
-  );
-}
-
-function DetailItem({
-  icon: Icon,
-  label,
-  value,
-}: {
-  icon: any;
-  label: string;
-  value: any;
-}) {
-  return (
-    <div className="flex items-center gap-2">
-      <Icon size={14} className="text-warm-400 flex-shrink-0" />
-      <div className="min-w-0">
-        <p className="text-xs text-warm-400">{label}</p>
-        <p className="text-sm text-warm-800 truncate">{String(value)}</p>
-      </div>
-    </div>
-  );
-}
-
-function DocThumbnail({
-  label,
-  url,
-  onPreview,
-}: {
-  label: string;
-  url: string | null;
-  onPreview: (url: string) => void;
-}) {
-  if (!url) {
-    return (
-      <div className="flex flex-col items-center justify-center p-3 bg-warm-50 rounded-lg border border-dashed border-warm-300 text-center">
-        <FileText size={16} className="text-warm-300 mb-1" />
-        <span className="text-xs text-warm-400">{label}</span>
-        <span className="text-xs text-warm-300">Not uploaded</span>
-      </div>
-    );
-  }
-
-  return (
-    <button
-      onClick={() => onPreview(url)}
-      className="flex flex-col items-center justify-center p-3 bg-green-50 rounded-lg border border-green-200 text-center hover:bg-green-100 transition-colors"
-    >
-      <Eye size={16} className="text-green-600 mb-1" />
-      <span className="text-xs text-green-700 font-medium">{label}</span>
-      <span className="text-xs text-green-500">View</span>
-    </button>
   );
 }

--- a/apps/admin/src/services/api.ts
+++ b/apps/admin/src/services/api.ts
@@ -22,8 +22,8 @@ async function request<T>(
   }
 
   if (!res.ok) {
-    const err = await res.json().catch(() => ({ message: 'Request failed' }));
-    throw new Error(err.message || `HTTP ${res.status}`);
+    const err = await res.json().catch(() => ({ error: 'Request failed' }));
+    throw new Error(err.error || err.message || `HTTP ${res.status}`);
   }
 
   return res.json();
@@ -62,10 +62,21 @@ export const deleteUser = (id: string) =>
 export const getPendingWorkers = () =>
   request<any>('/admin/workers/pending');
 
-export const verifyWorker = (id: string, status: 'VERIFIED' | 'REJECTED', rejectionReason?: string) =>
-  request<any>(`/users/${id}/verify`, {
+export const getAllWorkers = (status?: string) => {
+  const qs = status ? `?status=${status}` : '';
+  return request<any>(`/admin/workers${qs}`);
+};
+
+export const verifyWorker = (userId: string, data: {
+  status?: 'VERIFIED' | 'REJECTED' | 'PENDING';
+  rejectionReason?: string;
+  nicVerified?: boolean;
+  qualificationsVerified?: boolean;
+  backgroundCheckVerified?: boolean;
+}) =>
+  request<any>(`/users/${userId}/verify`, {
     method: 'PATCH',
-    body: JSON.stringify({ status, rejectionReason }),
+    body: JSON.stringify(data),
   });
 
 // Jobs
@@ -77,7 +88,7 @@ export const getJobs = (params: Record<string, string>) => {
 export const getJob = (id: string) => request<any>(`/jobs/${id}`);
 
 // Categories
-export const getCategories = () => request<any[]>('/categories');
+export const getCategories = () => request<any>('/categories');
 
 export const createCategory = (data: { name: string; description?: string; iconUrl?: string }) =>
   request<any>('/categories', {
@@ -100,5 +111,18 @@ export const getPayments = (params: Record<string, string>) => {
   return request<any>(`/admin/payments?${qs}`);
 };
 
+// Jobs - Admin Actions
+export const adminCloseJob = (id: string) =>
+  request<any>(`/admin/jobs/${id}/close`, { method: 'PATCH' });
+
 // Disputes
 export const getDisputes = () => request<any>('/admin/disputes');
+
+export const resolveDispute = (id: string, data: {
+  resolution: 'refund_customer' | 'pay_worker' | 'no_compensation';
+  notes?: string;
+}) =>
+  request<any>(`/admin/disputes/${id}/resolve`, {
+    method: 'PATCH',
+    body: JSON.stringify(data),
+  });

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -92,12 +92,15 @@ model WorkerProfile {
   latitude           Float?
   longitude          Float?
   nicNumber          String?
-  nicFrontUrl        String?
-  nicBackUrl         String?
-  backgroundCheckUrl String?
-  badgeLevel         BadgeLevel         @default(TRAINEE)
-  rejectionReason    String?
-  verificationStatus VerificationStatus @default(NOT_SUBMITTED)
+  nicFrontUrl            String?
+  nicBackUrl             String?
+  nicVerified            Boolean            @default(false)
+  qualificationsVerified Boolean            @default(false)
+  backgroundCheckUrl     String?
+  backgroundCheckVerified Boolean           @default(false)
+  badgeLevel             BadgeLevel         @default(TRAINEE)
+  rejectionReason        String?
+  verificationStatus     VerificationStatus @default(NOT_SUBMITTED)
   isAvailable        Boolean            @default(true)
   rating             Float              @default(0)
   totalJobs          Int                @default(0)

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -14,7 +14,7 @@ app.use(helmet());
 app.use(
   cors({
     origin: process.env.NODE_ENV === 'production'
-      ? [/* add production frontend URLs here */]
+      ? [process.env.FRONTEND_URL || 'https://admin.doer.lk']
       : true,
     credentials: true,
   })

--- a/apps/backend/src/routes/admin.ts
+++ b/apps/backend/src/routes/admin.ts
@@ -216,22 +216,54 @@ router.patch(
 );
 
 // ---------------------------------------------------------------------------
-// DELETE /admin/users/:id — Soft delete user (set isActive: false)
+// DELETE /admin/users/:id — Delete user and all associated data
 // ---------------------------------------------------------------------------
 router.delete(
   '/users/:id',
   asyncHandler(async (req: AuthRequest, res: Response) => {
+    const userId = req.params.id as string;
     const user = await prisma.user.findUnique({
-      where: { id: req.params.id as string },
+      where: { id: userId },
+      include: { customerProfile: true, workerProfile: true },
     });
     if (!user) throw AppError.notFound('User not found');
 
-    const updated = await prisma.user.update({
-      where: { id: req.params.id as string },
-      data: { isActive: false },
+    await prisma.$transaction(async (tx) => {
+      await tx.message.deleteMany({ where: { senderId: userId } });
+      await tx.notification.deleteMany({ where: { userId } });
+
+      if (user.customerProfile) {
+        const profileId = user.customerProfile.id;
+        const jobs = await tx.job.findMany({ where: { customerId: profileId }, select: { id: true } });
+        const jobIds = jobs.map((j) => j.id);
+        if (jobIds.length > 0) {
+          await tx.payment.deleteMany({ where: { jobId: { in: jobIds } } });
+          await tx.review.deleteMany({ where: { jobId: { in: jobIds } } });
+          await tx.message.deleteMany({ where: { jobId: { in: jobIds } } });
+          await tx.jobApplication.deleteMany({ where: { jobId: { in: jobIds } } });
+          await tx.job.deleteMany({ where: { id: { in: jobIds } } });
+        }
+        await tx.review.deleteMany({ where: { customerId: profileId } });
+        await tx.customerProfile.delete({ where: { id: profileId } });
+      }
+
+      if (user.workerProfile) {
+        const profileId = user.workerProfile.id;
+        await tx.workerCategory.deleteMany({ where: { workerId: profileId } });
+        await tx.jobApplication.deleteMany({ where: { workerId: profileId } });
+        await tx.review.deleteMany({ where: { workerId: profileId } });
+        await tx.portfolioItem.deleteMany({ where: { workerId: profileId } });
+        await tx.job.updateMany({
+          where: { workerId: profileId },
+          data: { workerId: null, status: 'CANCELLED' },
+        });
+        await tx.workerProfile.delete({ where: { id: profileId } });
+      }
+
+      await tx.user.delete({ where: { id: userId } });
     });
 
-    res.json({ message: 'User deactivated', user: updated });
+    res.json({ message: 'User deleted' });
   })
 );
 
@@ -251,6 +283,35 @@ router.get(
         qualificationDocs: true,
       },
       orderBy: { user: { createdAt: 'asc' } },
+    });
+
+    res.json({ workers });
+  })
+);
+
+// ---------------------------------------------------------------------------
+// GET /admin/workers — List all workers with optional status filter
+// ---------------------------------------------------------------------------
+router.get(
+  '/workers',
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    const { status } = req.query;
+
+    const where: any = {};
+    if (status && typeof status === 'string') {
+      where.verificationStatus = status;
+    }
+
+    const workers = await prisma.workerProfile.findMany({
+      where,
+      include: {
+        user: {
+          select: { id: true, name: true, email: true, phone: true, avatarUrl: true, createdAt: true },
+        },
+        categories: { include: { category: true } },
+        qualificationDocs: true,
+      },
+      orderBy: { user: { createdAt: 'desc' } },
     });
 
     res.json({ workers });
@@ -370,6 +431,131 @@ router.get(
 );
 
 // ---------------------------------------------------------------------------
+// PATCH /admin/jobs/:id/close — Admin closes a REVIEWING or COMPLETED job
+// ---------------------------------------------------------------------------
+router.patch(
+  '/jobs/:id/close',
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    const job = await prisma.job.findUnique({
+      where: { id: req.params.id as string },
+      include: {
+        customer: { include: { user: { select: { id: true, name: true } } } },
+        worker: { include: { user: { select: { id: true, name: true } } } },
+      },
+    });
+    if (!job) throw AppError.notFound('Job not found');
+    if (job.status !== 'REVIEWING' && job.status !== 'COMPLETED') {
+      throw AppError.badRequest('Job must be in REVIEWING or COMPLETED status to close');
+    }
+
+    const updated = await prisma.job.update({
+      where: { id: req.params.id as string },
+      data: { status: 'CLOSED' },
+      include: {
+        category: true,
+        customer: { include: { user: { select: { id: true, name: true } } } },
+        worker: { include: { user: { select: { id: true, name: true } } } },
+        payment: true,
+      },
+    });
+
+    // Notify both parties
+    const { createNotification } = await import('./notifications');
+    await createNotification(
+      job.customer.userId,
+      'Job Closed',
+      `Your job "${job.title}" has been closed by an administrator.`
+    );
+    if (job.worker) {
+      await createNotification(
+        job.worker.userId,
+        'Job Closed',
+        `The job "${job.title}" has been closed by an administrator.`
+      );
+    }
+
+    res.json({ job: updated });
+  })
+);
+
+// ---------------------------------------------------------------------------
+// PATCH /admin/disputes/:id/resolve — Resolve a dispute with compensation
+// ---------------------------------------------------------------------------
+const resolveDisputeSchema = z.object({
+  resolution: z.enum(['refund_customer', 'pay_worker', 'no_compensation']),
+  notes: z.string().optional(),
+});
+
+router.patch(
+  '/disputes/:id/resolve',
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    const { resolution, notes } = resolveDisputeSchema.parse(req.body);
+
+    const job = await prisma.job.findUnique({
+      where: { id: req.params.id as string },
+      include: {
+        customer: { include: { user: { select: { id: true, name: true } } } },
+        worker: { include: { user: { select: { id: true, name: true } } } },
+        payment: true,
+      },
+    });
+    if (!job) throw AppError.notFound('Job not found');
+    if (job.status !== 'CANCELLED') throw AppError.badRequest('Only cancelled jobs can be resolved as disputes');
+    if (!job.workerId) throw AppError.badRequest('No worker was assigned to this job');
+
+    // Update payment status based on resolution
+    if (job.payment) {
+      let paymentStatus = job.payment.status;
+      if (resolution === 'refund_customer') paymentStatus = 'REFUNDED';
+      else if (resolution === 'pay_worker') paymentStatus = 'COMPLETED';
+
+      if (paymentStatus !== job.payment.status) {
+        await prisma.payment.update({
+          where: { id: job.payment.id },
+          data: { status: paymentStatus },
+        });
+      }
+    }
+
+    // Notify both parties about the resolution
+    const { createNotification } = await import('./notifications');
+    const resolutionText =
+      resolution === 'refund_customer'
+        ? 'A refund will be issued to the customer.'
+        : resolution === 'pay_worker'
+        ? 'The worker will be compensated for their work.'
+        : 'No compensation will be issued.';
+
+    await createNotification(
+      job.customer.userId,
+      'Dispute Resolved',
+      `The dispute for "${job.title}" has been resolved. ${resolutionText}`
+    );
+    if (job.worker) {
+      await createNotification(
+        job.worker.userId,
+        'Dispute Resolved',
+        `The dispute for "${job.title}" has been resolved. ${resolutionText}`
+      );
+    }
+
+    res.json({
+      message: 'Dispute resolved',
+      resolution,
+      notes,
+      job: await prisma.job.findUnique({
+        where: { id: job.id },
+        include: {
+          customer: { include: { user: { select: { id: true, name: true } } } },
+          worker: { include: { user: { select: { id: true, name: true } } } },
+          payment: true,
+        },
+      }),
+    });
+  })
+);
+
+// ---------------------------------------------------------------------------
 // GET /admin/disputes — List disputed/cancelled jobs
 // ---------------------------------------------------------------------------
 router.get(
@@ -378,10 +564,7 @@ router.get(
     const disputes = await prisma.job.findMany({
       where: {
         status: 'CANCELLED',
-        OR: [
-          { review: { isNot: null } },
-          { messages: { some: {} } },
-        ],
+        workerId: { not: null },
       },
       include: {
         category: true,

--- a/apps/backend/src/routes/users.ts
+++ b/apps/backend/src/routes/users.ts
@@ -4,10 +4,10 @@ import prisma from '../config/prisma';
 import { authenticate, authorize, AuthRequest } from '../middleware/auth';
 import { asyncHandler } from '../utils/asyncHandler';
 import { AppError } from '../utils/AppError';
-import { upload } from '../middleware/upload';
-import { uploadToCloudinary } from '../config/cloudinary';
 import { recalculateAndNotifyBadge } from '../utils/badgeCalculator';
 import { createNotification } from './notifications';
+import { upload } from '../middleware/upload';
+import { uploadToCloudinary } from '../config/cloudinary';
 
 const router = Router();
 
@@ -56,7 +56,6 @@ router.get(
               orderBy: { createdAt: 'desc' },
               take: 20,
             },
-            qualificationDocs: true,
             portfolio: {
               include: { category: true },
               orderBy: { createdAt: 'desc' },
@@ -240,7 +239,6 @@ router.post(
       updateData.backgroundCheckUrl = await uploadToCloudinary(files.backgroundCheck[0].buffer, 'verification/background');
     }
 
-    // Upload qualifications
     if (files.qualifications?.length) {
       for (const file of files.qualifications) {
         const url = await uploadToCloudinary(file.buffer, 'verification/qualifications');
@@ -261,16 +259,14 @@ router.post(
     const profile = await prisma.workerProfile.update({
       where: { id: workerProfile.id },
       data: updateData,
-      include: {
-        qualificationDocs: true,
-      },
+      include: { qualificationDocs: true },
     });
 
     res.json({ profile });
   })
 );
 
-// GET /api/users/me/worker/verification — get verification status
+// GET /api/users/me/worker/verification — get worker's verification status and documents
 router.get(
   '/me/worker/verification',
   authenticate,
@@ -299,9 +295,13 @@ router.get(
       verificationStatus: worker.verificationStatus,
       badgeLevel: worker.badgeLevel,
       rejectionReason: worker.rejectionReason,
+      nicNumber: worker.nicNumber,
       nicFrontUrl: worker.nicFrontUrl,
       nicBackUrl: worker.nicBackUrl,
+      nicVerified: worker.nicVerified,
+      qualificationsVerified: worker.qualificationsVerified,
       backgroundCheckUrl: worker.backgroundCheckUrl,
+      backgroundCheckVerified: worker.backgroundCheckVerified,
       qualificationDocs: worker.qualificationDocs,
       nextBadge,
       nextBadgeHint: nextBadge ? nextBadgeInfo[nextBadge] : 'You have reached the highest level!',
@@ -309,47 +309,80 @@ router.get(
   })
 );
 
-// PATCH /api/users/:id/verify — admin verify/reject worker
+// PATCH /api/users/:id/verify — admin verify individual document types or overall status
 router.patch(
   '/:id/verify',
   authenticate,
   authorize('ADMIN'),
   asyncHandler(async (req: AuthRequest, res: Response) => {
-    const { status, rejectionReason } = z.object({
-      status: z.enum(['VERIFIED', 'REJECTED']),
+    const body = z.object({
+      // Overall status (legacy support)
+      status: z.enum(['VERIFIED', 'REJECTED', 'PENDING']).optional(),
       rejectionReason: z.string().optional(),
+      // Granular verification flags
+      nicVerified: z.boolean().optional(),
+      qualificationsVerified: z.boolean().optional(),
+      backgroundCheckVerified: z.boolean().optional(),
     }).parse(req.body);
 
-    if (status === 'REJECTED' && !rejectionReason) {
-      throw AppError.badRequest('Rejection reason is required when rejecting');
+    const updateData: any = {};
+
+    // Granular flags
+    if (body.nicVerified !== undefined) updateData.nicVerified = body.nicVerified;
+    if (body.qualificationsVerified !== undefined) updateData.qualificationsVerified = body.qualificationsVerified;
+    if (body.backgroundCheckVerified !== undefined) updateData.backgroundCheckVerified = body.backgroundCheckVerified;
+
+    // Overall status
+    if (body.status) {
+      updateData.verificationStatus = body.status;
+      updateData.rejectionReason = body.status === 'REJECTED' ? (body.rejectionReason || null) : null;
+      // Reset all flags when setting to PENDING or REJECTED
+      if (body.status === 'PENDING' || body.status === 'REJECTED') {
+        updateData.nicVerified = false;
+        updateData.qualificationsVerified = false;
+        updateData.backgroundCheckVerified = false;
+      }
+    }
+
+    // Auto-set overall status to VERIFIED if any doc is verified
+    if (body.nicVerified === true || body.qualificationsVerified === true || body.backgroundCheckVerified === true) {
+      updateData.verificationStatus = 'VERIFIED';
+      updateData.rejectionReason = null;
+    }
+
+    // Auto-downgrade overall status if any doc is revoked
+    if (body.nicVerified === false || body.qualificationsVerified === false || body.backgroundCheckVerified === false) {
+      updateData.verificationStatus = 'PENDING';
+      updateData.rejectionReason = null;
     }
 
     const profile = await prisma.workerProfile.update({
       where: { userId: req.params.id as string },
-      data: {
-        verificationStatus: status,
-        rejectionReason: status === 'REJECTED' ? rejectionReason : null,
-      },
+      data: updateData,
       include: {
         user: { select: { id: true, name: true, email: true } },
-        qualificationDocs: { select: { id: true } },
       },
     });
 
-    // Notify the worker
-    if (status === 'VERIFIED') {
-      await createNotification(
-        profile.userId,
-        'Verification Approved',
-        'Your identity has been verified. Welcome aboard!'
-      );
-      // Recalculate badge after verification
-      await recalculateAndNotifyBadge(profile.id);
-    } else {
+    // Recalculate badge based on new verification state
+    await recalculateAndNotifyBadge(profile.id);
+
+    // Notify worker
+    if (body.status === 'REJECTED') {
       await createNotification(
         profile.userId,
         'Verification Rejected',
-        `Your verification was rejected: ${rejectionReason}`
+        body.rejectionReason ? `Reason: ${body.rejectionReason}` : 'Please re-submit your documents.'
+      );
+    } else if (body.nicVerified || body.qualificationsVerified || body.backgroundCheckVerified) {
+      const verified = [];
+      if (body.nicVerified) verified.push('NIC');
+      if (body.qualificationsVerified) verified.push('Qualifications');
+      if (body.backgroundCheckVerified) verified.push('Background Check');
+      await createNotification(
+        profile.userId,
+        'Document Verified',
+        `Your ${verified.join(', ')} ${verified.length > 1 ? 'have' : 'has'} been verified!`
       );
     }
 

--- a/apps/backend/src/sockets/index.ts
+++ b/apps/backend/src/sockets/index.ts
@@ -10,7 +10,7 @@ export const getIO = (): Server | null => io;
 export const initSocket = (httpServer: HttpServer) => {
   io = new Server(httpServer, {
     cors: {
-      origin: process.env.NODE_ENV === 'production' ? [] : '*',
+      origin: process.env.NODE_ENV === 'production' ? [process.env.FRONTEND_URL || 'https://admin.doer.lk'] : '*',
       credentials: true,
     },
   });

--- a/apps/backend/src/utils/badgeCalculator.ts
+++ b/apps/backend/src/utils/badgeCalculator.ts
@@ -1,38 +1,34 @@
-import { BadgeLevel, VerificationStatus } from '@prisma/client';
+import { BadgeLevel } from '@prisma/client';
 import prisma from '../config/prisma';
 import { createNotification } from '../routes/notifications';
 
 interface WorkerForBadge {
   id: string;
   userId: string;
-  verificationStatus: VerificationStatus;
-  backgroundCheckUrl: string | null;
+  nicVerified: boolean;
+  qualificationsVerified: boolean;
+  backgroundCheckVerified: boolean;
   rating: number;
   totalJobs: number;
   badgeLevel: BadgeLevel;
-  qualificationDocs: { id: string }[];
 }
 
 export function calculateBadgeLevel(worker: WorkerForBadge): BadgeLevel {
-  const isVerified = worker.verificationStatus === 'VERIFIED';
-  const hasQualifications = worker.qualificationDocs.length > 0;
-  const hasBackgroundCheck = !!worker.backgroundCheckUrl;
-
-  // Platinum: Full verification + background check + 50+ jobs + 4.5+ rating
+  // Platinum: All 3 verified + background check + 50+ jobs + 4.5+ rating
   if (
-    isVerified &&
-    hasQualifications &&
-    hasBackgroundCheck &&
+    worker.nicVerified &&
+    worker.qualificationsVerified &&
+    worker.backgroundCheckVerified &&
     worker.totalJobs >= 50 &&
     worker.rating >= 4.5
   ) {
     return BadgeLevel.PLATINUM;
   }
 
-  // Gold: Full verification + 10+ jobs + 4.0+ rating
+  // Gold: NIC + qualifications verified + 10+ jobs + 4.0+ rating
   if (
-    isVerified &&
-    hasQualifications &&
+    worker.nicVerified &&
+    worker.qualificationsVerified &&
     worker.totalJobs >= 10 &&
     worker.rating >= 4.0
   ) {
@@ -40,12 +36,12 @@ export function calculateBadgeLevel(worker: WorkerForBadge): BadgeLevel {
   }
 
   // Silver: NIC + qualifications verified
-  if (isVerified && hasQualifications) {
+  if (worker.nicVerified && worker.qualificationsVerified) {
     return BadgeLevel.SILVER;
   }
 
   // Bronze: NIC verified
-  if (isVerified) {
+  if (worker.nicVerified) {
     return BadgeLevel.BRONZE;
   }
 
@@ -63,7 +59,6 @@ const BADGE_LABELS: Record<BadgeLevel, string> = {
 export async function recalculateAndNotifyBadge(workerId: string): Promise<BadgeLevel> {
   const worker = await prisma.workerProfile.findUnique({
     where: { id: workerId },
-    include: { qualificationDocs: { select: { id: true } } },
   });
 
   if (!worker) return BadgeLevel.TRAINEE;
@@ -71,16 +66,21 @@ export async function recalculateAndNotifyBadge(workerId: string): Promise<Badge
   const newLevel = calculateBadgeLevel(worker);
 
   if (newLevel !== worker.badgeLevel) {
+    const oldLevel = worker.badgeLevel;
     await prisma.workerProfile.update({
       where: { id: workerId },
       data: { badgeLevel: newLevel },
     });
 
-    await createNotification(
-      worker.userId,
-      'Badge Level Up!',
-      `Congratulations! You've reached ${BADGE_LABELS[newLevel]} level.`
-    );
+    // Only notify on level up, not down
+    const levels = [BadgeLevel.TRAINEE, BadgeLevel.BRONZE, BadgeLevel.SILVER, BadgeLevel.GOLD, BadgeLevel.PLATINUM];
+    if (levels.indexOf(newLevel) > levels.indexOf(oldLevel)) {
+      await createNotification(
+        worker.userId,
+        'Badge Level Up!',
+        `Congratulations! You've reached ${BADGE_LABELS[newLevel]} level.`
+      );
+    }
   }
 
   return newLevel;

--- a/apps/mobile-worker/lib/features/verification/screens/verification_screens.dart
+++ b/apps/mobile-worker/lib/features/verification/screens/verification_screens.dart
@@ -30,7 +30,10 @@ class _VerificationScreenState extends State<VerificationScreen> {
   String? _rejectionReason;
   String? _nicFrontUrl;
   String? _nicBackUrl;
+  bool _nicVerified = false;
+  bool _qualificationsVerified = false;
   String? _backgroundCheckUrl;
+  bool _backgroundCheckVerified = false;
   List<dynamic> _qualificationDocs = [];
   String? _nextBadge;
   String _nextBadgeHint = '';
@@ -51,7 +54,10 @@ class _VerificationScreenState extends State<VerificationScreen> {
         _rejectionReason = data['rejectionReason'];
         _nicFrontUrl = data['nicFrontUrl'];
         _nicBackUrl = data['nicBackUrl'];
+        _nicVerified = data['nicVerified'] == true;
+        _qualificationsVerified = data['qualificationsVerified'] == true;
         _backgroundCheckUrl = data['backgroundCheckUrl'];
+        _backgroundCheckVerified = data['backgroundCheckVerified'] == true;
         _qualificationDocs = data['qualificationDocs'] ?? [];
         _nextBadge = data['nextBadge'];
         _nextBadgeHint = data['nextBadgeHint'] ?? '';
@@ -166,8 +172,8 @@ class _VerificationScreenState extends State<VerificationScreen> {
             // NIC Verification
             VerificationCard(
               title: 'National Identity Card',
-              subtitle: _nicFrontUrl != null ? 'Documents uploaded' : 'Upload front & back of your NIC',
-              status: _nicFrontUrl != null ? displayStatus : VerificationStatus.pending,
+              subtitle: _nicVerified ? 'Verified' : _nicFrontUrl != null ? 'Pending review' : 'Upload front & back of your NIC',
+              status: _nicVerified ? VerificationStatus.approved : _nicFrontUrl != null ? VerificationStatus.submitted : VerificationStatus.pending,
               icon: Icons.badge_outlined,
               onTap: () async {
                 final result = await Navigator.push(
@@ -183,10 +189,10 @@ class _VerificationScreenState extends State<VerificationScreen> {
             // Qualification documents
             VerificationCard(
               title: 'Qualifications & Certificates',
-              subtitle: _qualificationDocs.isNotEmpty
-                  ? '${_qualificationDocs.length} document(s) uploaded'
+              subtitle: _qualificationsVerified ? 'Verified' : _qualificationDocs.isNotEmpty
+                  ? '${_qualificationDocs.length} document(s) — pending review'
                   : 'Upload skill certificates or trade licenses',
-              status: _qualificationDocs.isNotEmpty ? displayStatus : VerificationStatus.pending,
+              status: _qualificationsVerified ? VerificationStatus.approved : _qualificationDocs.isNotEmpty ? VerificationStatus.submitted : VerificationStatus.pending,
               icon: Icons.workspace_premium_outlined,
               onTap: () async {
                 final result = await Navigator.push(
@@ -202,8 +208,8 @@ class _VerificationScreenState extends State<VerificationScreen> {
             // Background check
             VerificationCard(
               title: 'Background Check',
-              subtitle: _backgroundCheckUrl != null ? 'Certificate uploaded' : 'Police clearance certificate',
-              status: _backgroundCheckUrl != null ? displayStatus : VerificationStatus.pending,
+              subtitle: _backgroundCheckVerified ? 'Verified' : _backgroundCheckUrl != null ? 'Pending review' : 'Police clearance certificate',
+              status: _backgroundCheckVerified ? VerificationStatus.approved : _backgroundCheckUrl != null ? VerificationStatus.submitted : VerificationStatus.pending,
               icon: Icons.security_outlined,
               onTap: () {
                 _showBackgroundCheckUpload(context);
@@ -291,13 +297,51 @@ class _VerificationScreenState extends State<VerificationScreen> {
           children: [
             Text('Background Check', style: AppTypography.headlineLarge),
             const SizedBox(height: 12),
-            Text(
-              'A background check requires submitting a Police Clearance Certificate (PCC) from your local police station.\n\nThis is reviewed manually by our team within 3-5 business days.',
-              style: AppTypography.bodyMedium.copyWith(color: AppColors.textSecondary),
-            ),
+            if (_backgroundCheckUrl != null) ...[
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: _backgroundCheckVerified ? AppColors.successLight : AppColors.surfaceVariant,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Row(children: [
+                  Icon(
+                    _backgroundCheckVerified ? Icons.check_circle_rounded : Icons.hourglass_top_rounded,
+                    color: _backgroundCheckVerified ? AppColors.success : AppColors.warning,
+                    size: 20,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      _backgroundCheckVerified ? 'Certificate verified' : 'Certificate uploaded — pending review',
+                      style: AppTypography.bodyMedium,
+                    ),
+                  ),
+                  GestureDetector(
+                    onTap: () {
+                      Navigator.pop(context);
+                      Navigator.push(context, MaterialPageRoute(
+                        builder: (_) => Scaffold(
+                          backgroundColor: Colors.black,
+                          appBar: AppBar(backgroundColor: Colors.black, foregroundColor: Colors.white),
+                          body: Center(child: InteractiveViewer(child: Image.network(_backgroundCheckUrl!, fit: BoxFit.contain))),
+                        ),
+                      ));
+                    },
+                    child: Text('View', style: AppTypography.labelMedium.copyWith(color: AppColors.primary)),
+                  ),
+                ]),
+              ),
+              const SizedBox(height: 12),
+            ] else ...[
+              Text(
+                'A background check requires submitting a Police Clearance Certificate (PCC) from your local police station.\n\nThis is reviewed manually by our team within 3-5 business days.',
+                style: AppTypography.bodyMedium.copyWith(color: AppColors.textSecondary),
+              ),
+            ],
             const SizedBox(height: 20),
             DoerButton(
-              label: 'Upload Police Certificate',
+              label: _backgroundCheckUrl != null ? 'Re-upload Certificate' : 'Upload Police Certificate',
               onPressed: () async {
                 Navigator.pop(context);
                 final picker = ImagePicker();
@@ -391,6 +435,29 @@ class _NicUploadScreenState extends State<NicUploadScreen> {
   bool _isSubmitting = false;
   final _nicController = TextEditingController();
   final _picker = ImagePicker();
+  String? _existingFrontUrl;
+  String? _existingBackUrl;
+  bool _nicVerified = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadExisting();
+  }
+
+  Future<void> _loadExisting() async {
+    try {
+      final data = await ApiService().getVerificationStatus();
+      if (mounted) {
+        setState(() {
+          _nicController.text = data['nicNumber'] ?? '';
+          _existingFrontUrl = data['nicFrontUrl'];
+          _existingBackUrl = data['nicBackUrl'];
+          _nicVerified = data['nicVerified'] == true;
+        });
+      }
+    } catch (_) {}
+  }
 
   @override
   void dispose() {
@@ -453,7 +520,9 @@ class _NicUploadScreenState extends State<NicUploadScreen> {
   @override
   Widget build(BuildContext context) {
     final nicFilled = _nicController.text.trim().isNotEmpty;
-    final canSubmit = _frontFile != null && _backFile != null && nicFilled;
+    final hasFront = _frontFile != null || _existingFrontUrl != null;
+    final hasBack = _backFile != null || _existingBackUrl != null;
+    final canSubmit = (_frontFile != null || _backFile != null) && nicFilled;
 
     return Scaffold(
       backgroundColor: AppColors.background,
@@ -500,6 +569,7 @@ class _NicUploadScreenState extends State<NicUploadScreen> {
               label: 'NIC Front',
               icon: Icons.credit_card_outlined,
               file: _frontFile,
+              existingUrl: _existingFrontUrl,
               onTap: () => _pickImage(true),
             ),
 
@@ -509,8 +579,28 @@ class _NicUploadScreenState extends State<NicUploadScreen> {
               label: 'NIC Back',
               icon: Icons.credit_card_outlined,
               file: _backFile,
+              existingUrl: _existingBackUrl,
               onTap: () => _pickImage(false),
             ),
+
+            if (_nicVerified)
+              Padding(
+                padding: const EdgeInsets.only(top: 12),
+                child: Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: AppColors.successLight,
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Row(
+                    children: [
+                      const Icon(Icons.check_circle_rounded, color: AppColors.success, size: 20),
+                      const SizedBox(width: 8),
+                      Text('NIC Verified', style: AppTypography.headlineSmall.copyWith(color: AppColors.success)),
+                    ],
+                  ),
+                ),
+              ),
 
             const Spacer(),
 
@@ -542,8 +632,28 @@ class QualificationUploadScreen extends StatefulWidget {
 class _QualificationUploadScreenState
     extends State<QualificationUploadScreen> {
   final List<File> _selectedFiles = [];
+  List<dynamic> _existingDocs = [];
+  bool _qualificationsVerified = false;
   bool _isSubmitting = false;
   final _picker = ImagePicker();
+
+  @override
+  void initState() {
+    super.initState();
+    _loadExisting();
+  }
+
+  Future<void> _loadExisting() async {
+    try {
+      final data = await ApiService().getVerificationStatus();
+      if (mounted) {
+        setState(() {
+          _existingDocs = data['qualificationDocs'] ?? [];
+          _qualificationsVerified = data['qualificationsVerified'] == true;
+        });
+      }
+    } catch (_) {}
+  }
 
   Future<void> _addDocument() async {
     final picked = await _picker.pickImage(source: ImageSource.gallery, imageQuality: 80);
@@ -597,7 +707,61 @@ class _QualificationUploadScreenState
               style: AppTypography.bodyMedium.copyWith(color: AppColors.textSecondary),
             ),
 
+            if (_qualificationsVerified)
+              Padding(
+                padding: const EdgeInsets.only(top: 12),
+                child: Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: AppColors.successLight,
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Row(children: [
+                    const Icon(Icons.check_circle_rounded, color: AppColors.success, size: 20),
+                    const SizedBox(width: 8),
+                    Text('Qualifications Verified', style: AppTypography.headlineSmall.copyWith(color: AppColors.success)),
+                  ]),
+                ),
+              ),
+
             const SizedBox(height: 24),
+
+            // Existing uploaded docs
+            if (_existingDocs.isNotEmpty) ...[
+              Text('Previously Uploaded', style: AppTypography.labelMedium),
+              const SizedBox(height: 8),
+              ..._existingDocs.map((doc) => Padding(
+                    padding: const EdgeInsets.only(bottom: 8),
+                    child: GestureDetector(
+                      onTap: () {
+                        if (doc['url'] != null) {
+                          Navigator.push(context, MaterialPageRoute(
+                            builder: (_) => Scaffold(
+                              backgroundColor: Colors.black,
+                              appBar: AppBar(backgroundColor: Colors.black, foregroundColor: Colors.white),
+                              body: Center(child: InteractiveViewer(child: Image.network(doc['url'], fit: BoxFit.contain))),
+                            ),
+                          ));
+                        }
+                      },
+                      child: Container(
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: AppColors.surface,
+                          borderRadius: BorderRadius.circular(12),
+                          border: Border.all(color: AppColors.border),
+                        ),
+                        child: Row(children: [
+                          const Icon(Icons.description_outlined, size: 20, color: AppColors.primary),
+                          const SizedBox(width: 10),
+                          Expanded(child: Text(doc['title'] ?? 'Document', style: AppTypography.bodyMedium)),
+                          const Icon(Icons.open_in_new_rounded, size: 16, color: AppColors.textTertiary),
+                        ]),
+                      ),
+                    ),
+                  )),
+              const SizedBox(height: 16),
+            ],
 
             // Selected files list
             ..._selectedFiles.asMap().entries.map((entry) => Padding(
@@ -680,18 +844,22 @@ class _ImageUploadCard extends StatelessWidget {
   final String label;
   final IconData icon;
   final File? file;
+  final String? existingUrl;
   final VoidCallback onTap;
 
   const _ImageUploadCard({
     required this.label,
     required this.icon,
     required this.file,
+    this.existingUrl,
     required this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
-    final isUploaded = file != null;
+    final hasLocal = file != null;
+    final hasRemote = existingUrl != null && existingUrl!.isNotEmpty;
+    final hasImage = hasLocal || hasRemote;
 
     return GestureDetector(
       onTap: onTap,
@@ -699,27 +867,34 @@ class _ImageUploadCard extends StatelessWidget {
         width: double.infinity,
         padding: const EdgeInsets.all(20),
         decoration: BoxDecoration(
-          color: isUploaded ? AppColors.successLight : AppColors.surface,
+          color: hasImage ? AppColors.successLight : AppColors.surface,
           borderRadius: BorderRadius.circular(16),
           border: Border.all(
-            color: isUploaded
+            color: hasImage
                 ? AppColors.success.withValues(alpha: 0.4)
                 : AppColors.border,
           ),
         ),
-        child: isUploaded
+        child: hasImage
             ? Row(
                 children: [
                   ClipRRect(
                     borderRadius: BorderRadius.circular(8),
-                    child: Image.file(file!, width: 60, height: 60, fit: BoxFit.cover),
+                    child: hasLocal
+                        ? Image.file(file!, width: 60, height: 60, fit: BoxFit.cover)
+                        : Image.network(existingUrl!, width: 60, height: 60, fit: BoxFit.cover,
+                            errorBuilder: (_, __, ___) => Container(
+                              width: 60, height: 60, color: AppColors.surfaceVariant,
+                              child: const Icon(Icons.image_outlined, color: AppColors.textTertiary),
+                            )),
                   ),
                   const SizedBox(width: 14),
                   Expanded(
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text('$label uploaded', style: AppTypography.headlineSmall.copyWith(color: AppColors.success)),
+                        Text(hasLocal ? '$label ready to upload' : '$label uploaded',
+                            style: AppTypography.headlineSmall.copyWith(color: AppColors.success)),
                         const SizedBox(height: 2),
                         Text('Tap to change', style: AppTypography.labelSmall),
                       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
       }
     },
     "apps/backend": {
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
         "@googlemaps/google-maps-services-js": "^3.4.0",


### PR DESCRIPTION
- Add admin ability to close jobs stuck in REVIEWING/COMPLETED status
 Rework disputes page to only show cancelled jobs that had workers assigned, with compensation resolution options (refund customer, pay worker, or no compensation)
- Fix user management, verification workflow, and category pages in admin panel
-  Update badge calculator and worker verification schema

  ## Changes
  - **Backend: Add `PATCH /admin/jobs/:id/close` and `PATCH /admin/disputes/:id/resolve` endpoints with
  notifications
  - Backend: Filter disputes to exclude cancelled jobs with no worker assigned
  - Backend: Schema and route fixes for user management and verification
  - Admin: Job detail modal now shows "Close Job" button for REVIEWING/COMPLETED jobs
  - Admin: Disputes page redesigned with resolution options and notes
  - Admin: Fixes across Users, Verification, and Categories pages
  - Mobile Worker: Expanded verification screen functionality